### PR TITLE
Fix Var::Many prefix formatting

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -53,8 +53,8 @@ impl Display for Var {
                         f,
                         "{}_{}_{}=({})",
                         PREFIX,
-                        name,
                         prefix.iter().format("_"),
+                        name,
                         values.iter().join(" ")
                     )
                 }

--- a/tests/command.rs
+++ b/tests/command.rs
@@ -109,6 +109,37 @@ fn test_subcommand() {
     insta::assert_snapshot!(output);
 }
 
+#[test]
+fn test_subcommand_many() {
+    let app: Command = toml::from_str(
+        r#"
+            name = "myprog"
+            [args]
+            arg1 = {}
+            [[subcommands]]
+            name = "subcommand"
+            about = "a sub command"
+                [subcommands.args]
+                arg2 = {}
+                  [[subcommands.subcommands]]
+                  name  = "nested"
+                  about = "A nested sub command"
+                    [subcommands.subcommands.args]
+                    arg3 = { long = "arg3", action = "append" }
+            [[subcommands]]
+            name = "subcommand2"
+            about = "another sub command"
+                [subcommands.args]
+                arg4 = {}
+        "#,
+    )
+    .unwrap();
+    let input = "subcommand nested --arg3 one --arg3 two";
+    let args: Vec<OsString> = input.split(" ").map(OsString::from).collect();
+    let output = parse(app, args);
+    insta::assert_snapshot!(output);
+}
+
 // TODO: error
 
 #[test]

--- a/tests/snapshots/command__subcommand_many.snap
+++ b/tests/snapshots/command__subcommand_many.snap
@@ -1,0 +1,5 @@
+---
+source: tests/command.rs
+expression: output
+---
+claptrap_subcommand_nested_arg3=(one two)


### PR DESCRIPTION
## Summary
- correct prefix order in `Var::Many`
- add a regression test for subcommand variables with multiple values

## Testing
- `INSTA_UPDATE=always cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684fab14890c832999f7b868b9cefc43