### PR TITLE
Ensure unique heredoc delimiter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,6 +139,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "clap_mangen",
+ "crc32fast",
  "indexmap",
  "insta",
  "itertools",
@@ -166,6 +167,15 @@ dependencies = [
  "libc",
  "once_cell",
  "windows-sys",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ anyhow = "1.0.98"
 clap = { version = "4.5.39", features = ["derive", "string", "cargo", "wrap_help", "usage", "unstable-styles", "color", "suggestions", "error-context", "env"] }
 clap_complete = "4.5.54"
 clap_mangen = "0.2.27"
+crc32fast = "1.4.2"
 indexmap = { version = "2.9.0", features = ["serde"] }
 itertools = "0.14.0"
 serde = { version = "1.0.219", features = ["derive"] }

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,4 +1,5 @@
 use clap::builder::StyledStr;
+use crc32fast::hash;
 use itertools::Itertools;
 
 fn shell_quote(value: &str) -> String {
@@ -103,11 +104,15 @@ impl CatCmd {
 
 impl Display for CatCmd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let msg = format!("{}", self.data.ansi());
+        let mut delimiter = format!("EOF_{:08x}", hash(msg.as_bytes()));
+        while msg.contains(&delimiter) {
+            delimiter.push('_');
+        }
         write!(
             f,
-            "command cat <<'EOF'\n{}EOF\nexit {}",
-            self.data.ansi(),
-            self.exit_code
+            "command cat <<'{}'\n{}{}\nexit {}",
+            delimiter, msg, delimiter, self.exit_code
         )
     }
 }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1,4 +1,5 @@
 use claptrap::command::Command;
+use claptrap::output::{CatCmd, ExitCode};
 use claptrap::parse;
 use std::ffi::OsString;
 
@@ -54,4 +55,11 @@ fn it_outputs_error_and_exit_1_on_unexpected_arg() {
     let args: Vec<OsString> = vec!["--invalid".into()];
     let output = parse(app, args);
     insta::assert_snapshot!(output);
+}
+
+#[test]
+fn cat_cmd_handles_eof_in_message() {
+    let styled = clap::builder::StyledStr::from("this contains EOF in the text\nEOF\nand more\n");
+    let cmd = CatCmd::new(styled, ExitCode::Error);
+    insta::assert_snapshot!(format!("{}", cmd));
 }

--- a/tests/snapshots/arg__action_help.snap
+++ b/tests/snapshots/arg__action_help.snap
@@ -2,11 +2,11 @@
 source: tests/arg.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_8d61f119'
 [1m[4mUsage:[0m [1mprog[0m
 
 [1m[4mOptions:[0m
       [1m--flag[0m  
   [1m-h[0m, [1m--help[0m  Print help
-EOF
+EOF_8d61f119
 exit 0

--- a/tests/snapshots/arg__action_help_long.snap
+++ b/tests/snapshots/arg__action_help_long.snap
@@ -2,11 +2,11 @@
 source: tests/arg.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_8d61f119'
 [1m[4mUsage:[0m [1mprog[0m
 
 [1m[4mOptions:[0m
       [1m--flag[0m  
   [1m-h[0m, [1m--help[0m  Print help
-EOF
+EOF_8d61f119
 exit 0

--- a/tests/snapshots/arg__action_help_short.snap
+++ b/tests/snapshots/arg__action_help_short.snap
@@ -2,11 +2,11 @@
 source: tests/arg.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_8d61f119'
 [1m[4mUsage:[0m [1mprog[0m
 
 [1m[4mOptions:[0m
       [1m--flag[0m  
   [1m-h[0m, [1m--help[0m  Print help
-EOF
+EOF_8d61f119
 exit 0

--- a/tests/snapshots/arg__action_version.snap
+++ b/tests/snapshots/arg__action_version.snap
@@ -2,7 +2,7 @@
 source: tests/arg.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_bdec613a'
 prog 1.0.0
-EOF
+EOF_bdec613a
 exit 0

--- a/tests/snapshots/arg__conflicts_with.snap
+++ b/tests/snapshots/arg__conflicts_with.snap
@@ -2,11 +2,11 @@
 source: tests/arg.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_285fe05b'
 [1m[31merror:[0m the argument '[33m--debug[0m' cannot be used with '[33m--config <cfg>[0m'
 
 [1m[4mUsage:[0m [1mprog[0m [1m--debug[0m
 
 For more information, try '[1m--help[0m'.
-EOF
+EOF_285fe05b
 exit 1

--- a/tests/snapshots/arg__conflicts_with_all.snap
+++ b/tests/snapshots/arg__conflicts_with_all.snap
@@ -2,11 +2,11 @@
 source: tests/arg.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_a72bcec1'
 [1m[31merror:[0m the argument '[33m--config <cfg>[0m' cannot be used with '[33m[input][0m'
 
 [1m[4mUsage:[0m [1mprog[0m [1m--config[0m <cfg> [input]
 
 For more information, try '[1m--help[0m'.
-EOF
+EOF_a72bcec1
 exit 1

--- a/tests/snapshots/arg__display_order.snap
+++ b/tests/snapshots/arg__display_order.snap
@@ -2,7 +2,7 @@
 source: tests/arg.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_2ecc72db'
 [1m[4mUsage:[0m [1mprog[0m [OPTIONS]
 
 [1m[4mOptions:[0m
@@ -10,5 +10,5 @@ command cat <<'EOF'
   [1m-b[0m, [1m--boat[0m <boat>          Some help and text
   [1m-?[0m                         Alt help
   [1m-h[0m, [1m--help[0m                 Print help
-EOF
+EOF_2ecc72db
 exit 0

--- a/tests/snapshots/arg__exclusive.snap
+++ b/tests/snapshots/arg__exclusive.snap
@@ -2,11 +2,11 @@
 source: tests/arg.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_563070fc'
 [1m[31merror:[0m the argument '[33m--exclusive <exclusive>[0m' cannot be used with one or more of the other specified arguments
 
 [1m[4mUsage:[0m [1mprog[0m [OPTIONS] [input]
 
 For more information, try '[1m--help[0m'.
-EOF
+EOF_563070fc
 exit 1

--- a/tests/snapshots/arg__help.snap
+++ b/tests/snapshots/arg__help.snap
@@ -2,11 +2,11 @@
 source: tests/arg.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_02f3f945'
 [1m[4mUsage:[0m [1mprog[0m [OPTIONS]
 
 [1m[4mOptions:[0m
       [1m--config[0m <cfg>  Some help text describing the --config arg
   [1m-h[0m, [1m--help[0m          Print help
-EOF
+EOF_02f3f945
 exit 0

--- a/tests/snapshots/arg__help_heading.snap
+++ b/tests/snapshots/arg__help_heading.snap
@@ -2,7 +2,7 @@
 source: tests/arg.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_d25a9760'
 [1m[4mUsage:[0m [1mprog[0m [OPTIONS]
 
 [1m[4mOptions:[0m
@@ -10,5 +10,5 @@ command cat <<'EOF'
 
 [1m[4mConfiguration Options:[0m
       [1m--config[0m <cfg>  Some help text describing the --config arg
-EOF
+EOF_d25a9760
 exit 0

--- a/tests/snapshots/arg__hide.snap
+++ b/tests/snapshots/arg__hide.snap
@@ -2,10 +2,10 @@
 source: tests/arg.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_dd29d008'
 [1m[4mUsage:[0m [1mprog[0m
 
 [1m[4mOptions:[0m
   [1m-h[0m, [1m--help[0m  Print help
-EOF
+EOF_dd29d008
 exit 0

--- a/tests/snapshots/arg__hide_default_value.snap
+++ b/tests/snapshots/arg__hide_default_value.snap
@@ -2,11 +2,11 @@
 source: tests/arg.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_85c0eebe'
 [1m[4mUsage:[0m [1mconnect[0m [OPTIONS]
 
 [1m[4mOptions:[0m
       [1m--host[0m <host>  
   [1m-h[0m, [1m--help[0m         Print help
-EOF
+EOF_85c0eebe
 exit 0

--- a/tests/snapshots/arg__hide_env.snap
+++ b/tests/snapshots/arg__hide_env.snap
@@ -2,11 +2,11 @@
 source: tests/arg.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_84c9ada3'
 [1m[4mUsage:[0m [1mprog[0m [OPTIONS]
 
 [1m[4mOptions:[0m
       [1m--mode[0m <mode>  
   [1m-h[0m, [1m--help[0m         Print help
-EOF
+EOF_84c9ada3
 exit 0

--- a/tests/snapshots/arg__hide_env_values.snap
+++ b/tests/snapshots/arg__hide_env_values.snap
@@ -2,11 +2,11 @@
 source: tests/arg.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_192f0b15'
 [1m[4mUsage:[0m [1mconnect[0m [OPTIONS]
 
 [1m[4mOptions:[0m
       [1m--host[0m <host>  [env: CONNECT]
   [1m-h[0m, [1m--help[0m         Print help
-EOF
+EOF_192f0b15
 exit 0

--- a/tests/snapshots/arg__hide_long_help-2.snap
+++ b/tests/snapshots/arg__hide_long_help-2.snap
@@ -2,11 +2,11 @@
 source: tests/arg.rs
 expression: output2
 ---
-command cat <<'EOF'
+command cat <<'EOF_3cb344f0'
 [1m[4mUsage:[0m [1mprog[0m [OPTIONS]
 
 [1m[4mOptions:[0m
       [1m--config[0m <cfg>  Some help text describing the --config arg
   [1m-h[0m, [1m--help[0m          Print help (see more with '--help')
-EOF
+EOF_3cb344f0
 exit 0

--- a/tests/snapshots/arg__hide_long_help.snap
+++ b/tests/snapshots/arg__hide_long_help.snap
@@ -2,11 +2,11 @@
 source: tests/arg.rs
 expression: output1
 ---
-command cat <<'EOF'
+command cat <<'EOF_62231ac3'
 [1m[4mUsage:[0m [1mprog[0m [OPTIONS]
 
 [1m[4mOptions:[0m
   [1m-h[0m, [1m--help[0m
           Print help (see a summary with '-h')
-EOF
+EOF_62231ac3
 exit 0

--- a/tests/snapshots/arg__hide_possible_values.snap
+++ b/tests/snapshots/arg__hide_possible_values.snap
@@ -2,11 +2,11 @@
 source: tests/arg.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_84c9ada3'
 [1m[4mUsage:[0m [1mprog[0m [OPTIONS]
 
 [1m[4mOptions:[0m
       [1m--mode[0m <mode>  
   [1m-h[0m, [1m--help[0m         Print help
-EOF
+EOF_84c9ada3
 exit 0

--- a/tests/snapshots/arg__hide_short_help-2.snap
+++ b/tests/snapshots/arg__hide_short_help-2.snap
@@ -2,7 +2,7 @@
 source: tests/arg.rs
 expression: output2
 ---
-command cat <<'EOF'
+command cat <<'EOF_742b933a'
 [1m[4mUsage:[0m [1mprog[0m [OPTIONS]
 
 [1m[4mOptions:[0m
@@ -11,5 +11,5 @@ command cat <<'EOF'
 
   [1m-h[0m, [1m--help[0m
           Print help (see a summary with '-h')
-EOF
+EOF_742b933a
 exit 0

--- a/tests/snapshots/arg__hide_short_help.snap
+++ b/tests/snapshots/arg__hide_short_help.snap
@@ -2,10 +2,10 @@
 source: tests/arg.rs
 expression: output1
 ---
-command cat <<'EOF'
+command cat <<'EOF_202aaf82'
 [1m[4mUsage:[0m [1mprog[0m [OPTIONS]
 
 [1m[4mOptions:[0m
   [1m-h[0m, [1m--help[0m  Print help (see more with '--help')
-EOF
+EOF_202aaf82
 exit 0

--- a/tests/snapshots/arg__it_fails_when_action_set_false_twice.snap
+++ b/tests/snapshots/arg__it_fails_when_action_set_false_twice.snap
@@ -2,11 +2,11 @@
 source: tests/arg.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_2312ebac'
 [1m[31merror:[0m the argument '[33m--flag[0m' cannot be used multiple times
 
 [1m[4mUsage:[0m [1mprog[0m [OPTIONS]
 
 For more information, try '[1m--help[0m'.
-EOF
+EOF_2312ebac
 exit 1

--- a/tests/snapshots/arg__it_fails_when_action_set_true_twice.snap
+++ b/tests/snapshots/arg__it_fails_when_action_set_true_twice.snap
@@ -2,11 +2,11 @@
 source: tests/arg.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_2312ebac'
 [1m[31merror:[0m the argument '[33m--flag[0m' cannot be used multiple times
 
 [1m[4mUsage:[0m [1mprog[0m [OPTIONS]
 
 For more information, try '[1m--help[0m'.
-EOF
+EOF_2312ebac
 exit 1

--- a/tests/snapshots/arg__it_fails_when_action_set_twice.snap
+++ b/tests/snapshots/arg__it_fails_when_action_set_twice.snap
@@ -2,11 +2,11 @@
 source: tests/arg.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_5ba347da'
 [1m[31merror:[0m the argument '[33m--flag <flag>[0m' cannot be used multiple times
 
 [1m[4mUsage:[0m [1mprog[0m [OPTIONS]
 
 For more information, try '[1m--help[0m'.
-EOF
+EOF_5ba347da
 exit 1

--- a/tests/snapshots/arg__it_fails_when_not_allow_hyphen_values.snap
+++ b/tests/snapshots/arg__it_fails_when_not_allow_hyphen_values.snap
@@ -2,11 +2,11 @@
 source: tests/arg.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_5d71b639'
 [1m[31merror:[0m unexpected argument '[33m-f[0m' found
 
 [1m[4mUsage:[0m [1mprog[0m [OPTIONS]
 
 For more information, try '[1m--help[0m'.
-EOF
+EOF_5d71b639
 exit 1

--- a/tests/snapshots/arg__last-2.snap
+++ b/tests/snapshots/arg__last-2.snap
@@ -2,11 +2,11 @@
 source: tests/arg.rs
 expression: output2
 ---
-command cat <<'EOF'
+command cat <<'EOF_daf2159a'
 [1m[31merror:[0m unexpected argument '[33mthree[0m' found
 
 [1m[4mUsage:[0m [1mprog[0m [first] [second] [1m[--[0m <third>[1m][0m
 
 For more information, try '[1m--help[0m'.
-EOF
+EOF_daf2159a
 exit 1

--- a/tests/snapshots/arg__next_line_help.snap
+++ b/tests/snapshots/arg__next_line_help.snap
@@ -2,7 +2,7 @@
 source: tests/arg.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_9eb35108'
 [1m[4mUsage:[0m [1mprog[0m [OPTIONS]
 
 [1m[4mOptions:[0m
@@ -12,5 +12,5 @@ command cat <<'EOF'
           on a line after the option
   [1m-h[0m, [1m--help[0m
           Print help
-EOF
+EOF_9eb35108
 exit 0

--- a/tests/snapshots/arg__num_args_tuples-2.snap
+++ b/tests/snapshots/arg__num_args_tuples-2.snap
@@ -2,11 +2,11 @@
 source: tests/arg.rs
 expression: output2
 ---
-command cat <<'EOF'
+command cat <<'EOF_ad1f8bf9'
 [1m[31merror:[0m [32m2[0m values required for '[1m-F <file> <file>[0m' but [33m1[0m was provided
 
 [1m[4mUsage:[0m [1mprog[0m [OPTIONS]
 
 For more information, try '[1m--help[0m'.
-EOF
+EOF_ad1f8bf9
 exit 1

--- a/tests/snapshots/arg__require_equals-2.snap
+++ b/tests/snapshots/arg__require_equals-2.snap
@@ -2,11 +2,11 @@
 source: tests/arg.rs
 expression: output2
 ---
-command cat <<'EOF'
+command cat <<'EOF_0d82cede'
 [1m[31merror:[0m equal sign is needed when assigning values to '[33m--config=<cfg>[0m'
 
 [1m[4mUsage:[0m [1mprog[0m [OPTIONS]
 
 For more information, try '[1m--help[0m'.
-EOF
+EOF_0d82cede
 exit 1

--- a/tests/snapshots/arg__required-2.snap
+++ b/tests/snapshots/arg__required-2.snap
@@ -2,12 +2,12 @@
 source: tests/arg.rs
 expression: output2
 ---
-command cat <<'EOF'
+command cat <<'EOF_0683a44a'
 [1m[31merror:[0m the following required arguments were not provided:
   [32m--config <cfg>[0m
 
 [1m[4mUsage:[0m [1mprog[0m [1m--config[0m <cfg>
 
 For more information, try '[1m--help[0m'.
-EOF
+EOF_0683a44a
 exit 1

--- a/tests/snapshots/arg__required_unless_present-2.snap
+++ b/tests/snapshots/arg__required_unless_present-2.snap
@@ -2,12 +2,12 @@
 source: tests/arg.rs
 expression: output2
 ---
-command cat <<'EOF'
+command cat <<'EOF_0683a44a'
 [1m[31merror:[0m the following required arguments were not provided:
   [32m--config <cfg>[0m
 
 [1m[4mUsage:[0m [1mprog[0m [1m--config[0m <cfg>
 
 For more information, try '[1m--help[0m'.
-EOF
+EOF_0683a44a
 exit 1

--- a/tests/snapshots/arg__required_unless_present_all-2.snap
+++ b/tests/snapshots/arg__required_unless_present_all-2.snap
@@ -2,12 +2,12 @@
 source: tests/arg.rs
 expression: output2
 ---
-command cat <<'EOF'
+command cat <<'EOF_0683a44a'
 [1m[31merror:[0m the following required arguments were not provided:
   [32m--config <cfg>[0m
 
 [1m[4mUsage:[0m [1mprog[0m [1m--config[0m <cfg>
 
 For more information, try '[1m--help[0m'.
-EOF
+EOF_0683a44a
 exit 1

--- a/tests/snapshots/arg__required_unless_present_any-2.snap
+++ b/tests/snapshots/arg__required_unless_present_any-2.snap
@@ -2,12 +2,12 @@
 source: tests/arg.rs
 expression: output2
 ---
-command cat <<'EOF'
+command cat <<'EOF_0683a44a'
 [1m[31merror:[0m the following required arguments were not provided:
   [32m--config <cfg>[0m
 
 [1m[4mUsage:[0m [1mprog[0m [1m--config[0m <cfg>
 
 For more information, try '[1m--help[0m'.
-EOF
+EOF_0683a44a
 exit 1

--- a/tests/snapshots/arg__requires-2.snap
+++ b/tests/snapshots/arg__requires-2.snap
@@ -2,12 +2,12 @@
 source: tests/arg.rs
 expression: output2
 ---
-command cat <<'EOF'
+command cat <<'EOF_84e1a07a'
 [1m[31merror:[0m the following required arguments were not provided:
   [32m<input>[0m
 
 [1m[4mUsage:[0m [1mprog[0m [1m--config[0m <cfg> <input>
 
 For more information, try '[1m--help[0m'.
-EOF
+EOF_84e1a07a
 exit 1

--- a/tests/snapshots/arg__value_name.snap
+++ b/tests/snapshots/arg__value_name.snap
@@ -2,11 +2,11 @@
 source: tests/arg.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_6a646d29'
 [1m[4mUsage:[0m [1mprog[0m [OPTIONS]
 
 [1m[4mOptions:[0m
       [1m--config[0m <FILE>  
   [1m-h[0m, [1m--help[0m           Print help
-EOF
+EOF_6a646d29
 exit 0

--- a/tests/snapshots/arg__value_names.snap
+++ b/tests/snapshots/arg__value_names.snap
@@ -2,11 +2,11 @@
 source: tests/arg.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_cd78e46e'
 [1m[4mUsage:[0m [1mprog[0m [OPTIONS]
 
 [1m[4mOptions:[0m
       [1m--io-files[0m <INFILE> <OUTFILE>  
   [1m-h[0m, [1m--help[0m                         Print help
-EOF
+EOF_cd78e46e
 exit 0

--- a/tests/snapshots/arg_group__conflicts_with.snap
+++ b/tests/snapshots/arg_group__conflicts_with.snap
@@ -2,11 +2,11 @@
 source: tests/arg_group.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_224b398c'
 [1m[31merror:[0m the argument '[33m-c[0m' cannot be used with '[33m-d[0m'
 
 [1m[4mUsage:[0m [1mmyprog[0m [1m-c[0m
 
 For more information, try '[1m--help[0m'.
-EOF
+EOF_224b398c
 exit 1

--- a/tests/snapshots/arg_group__conflicts_with_all.snap
+++ b/tests/snapshots/arg_group__conflicts_with_all.snap
@@ -2,11 +2,11 @@
 source: tests/arg_group.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_ed2c5917'
 [1m[31merror:[0m the argument '[33m-c[0m' cannot be used with '[33m-v[0m'
 
 [1m[4mUsage:[0m [1mmyprog[0m [1m-c[0m
 
 For more information, try '[1m--help[0m'.
-EOF
+EOF_ed2c5917
 exit 1

--- a/tests/snapshots/arg_group__required.snap
+++ b/tests/snapshots/arg_group__required.snap
@@ -2,12 +2,12 @@
 source: tests/arg_group.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_fdfd176b'
 [1m[31merror:[0m the following required arguments were not provided:
   [32m<-f|-c>[0m
 
 [1m[4mUsage:[0m [1mmyprog[0m <-f|-c>
 
 For more information, try '[1m--help[0m'.
-EOF
+EOF_fdfd176b
 exit 1

--- a/tests/snapshots/arg_group__requires.snap
+++ b/tests/snapshots/arg_group__requires.snap
@@ -2,12 +2,12 @@
 source: tests/arg_group.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_464b25f5'
 [1m[31merror:[0m the following required arguments were not provided:
   [32m-d[0m
 
 [1m[4mUsage:[0m [1mmyprog[0m [1m-d[0m [1m-c[0m
 
 For more information, try '[1m--help[0m'.
-EOF
+EOF_464b25f5
 exit 1

--- a/tests/snapshots/arg_group__requires_all.snap
+++ b/tests/snapshots/arg_group__requires_all.snap
@@ -2,12 +2,12 @@
 source: tests/arg_group.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_bd3680b7'
 [1m[31merror:[0m the following required arguments were not provided:
   [32m-v[0m
 
 [1m[4mUsage:[0m [1mmyprog[0m [1m-d[0m [1m-v[0m [1m-c[0m
 
 For more information, try '[1m--help[0m'.
-EOF
+EOF_bd3680b7
 exit 1

--- a/tests/snapshots/basic__cat_cmd_handles_eof_in_message.snap
+++ b/tests/snapshots/basic__cat_cmd_handles_eof_in_message.snap
@@ -1,0 +1,10 @@
+---
+source: tests/basic.rs
+expression: "format!(\"{}\", cmd)"
+---
+command cat <<'EOF_16726ae4'
+this contains EOF in the text
+EOF
+and more
+EOF_16726ae4
+exit 1

--- a/tests/snapshots/basic__it_outputs_error_and_exit_1_on_unexpected_arg.snap
+++ b/tests/snapshots/basic__it_outputs_error_and_exit_1_on_unexpected_arg.snap
@@ -2,11 +2,11 @@
 source: tests/basic.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_96fc7ed9'
 [1m[31merror:[0m unexpected argument '[33m--invalid[0m' found
 
 [1m[4mUsage:[0m [1mmyapp[0m [OPTIONS]
 
 For more information, try '[1m--help[0m'.
-EOF
+EOF_96fc7ed9
 exit 1

--- a/tests/snapshots/basic__it_outputs_usage_and_exit_0_on_long_help.snap
+++ b/tests/snapshots/basic__it_outputs_usage_and_exit_0_on_long_help.snap
@@ -2,7 +2,7 @@
 source: tests/basic.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_89694ea0'
 [1m[4mUsage:[0m [1mmyapp[0m [OPTIONS]
 
 [1m[4mOptions:[0m
@@ -10,5 +10,5 @@ command cat <<'EOF'
   [1m-p[0m, [1m--protocol[0m <protocol>  
   [1m-h[0m, [1m--help[0m                 Print help
   [1m-V[0m, [1m--version[0m              Print version
-EOF
+EOF_89694ea0
 exit 0

--- a/tests/snapshots/basic__it_outputs_usage_and_exit_0_on_short_help.snap
+++ b/tests/snapshots/basic__it_outputs_usage_and_exit_0_on_short_help.snap
@@ -2,7 +2,7 @@
 source: tests/basic.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_89694ea0'
 [1m[4mUsage:[0m [1mmyapp[0m [OPTIONS]
 
 [1m[4mOptions:[0m
@@ -10,5 +10,5 @@ command cat <<'EOF'
   [1m-p[0m, [1m--protocol[0m <protocol>  
   [1m-h[0m, [1m--help[0m                 Print help
   [1m-V[0m, [1m--version[0m              Print version
-EOF
+EOF_89694ea0
 exit 0

--- a/tests/snapshots/basic__it_outputs_usage_and_exit_2_on_no_args.snap
+++ b/tests/snapshots/basic__it_outputs_usage_and_exit_2_on_no_args.snap
@@ -2,7 +2,7 @@
 source: tests/basic.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_89694ea0'
 [1m[4mUsage:[0m [1mmyapp[0m [OPTIONS]
 
 [1m[4mOptions:[0m
@@ -10,5 +10,5 @@ command cat <<'EOF'
   [1m-p[0m, [1m--protocol[0m <protocol>  
   [1m-h[0m, [1m--help[0m                 Print help
   [1m-V[0m, [1m--version[0m              Print version
-EOF
+EOF_89694ea0
 exit 2

--- a/tests/snapshots/basic__it_outputs_version_and_exit_0_on_short_version.snap
+++ b/tests/snapshots/basic__it_outputs_version_and_exit_0_on_short_version.snap
@@ -2,7 +2,7 @@
 source: tests/basic.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_da707e63'
 myapp 0.1.0
-EOF
+EOF_da707e63
 exit 0

--- a/tests/snapshots/command__about.snap
+++ b/tests/snapshots/command__about.snap
@@ -2,12 +2,12 @@
 source: tests/command.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_0dbb4049'
 Does really amazing things for great people
 
 [1m[4mUsage:[0m [1mmyprog[0m
 
 [1m[4mOptions:[0m
   [1m-h[0m, [1m--help[0m  Print help
-EOF
+EOF_0dbb4049
 exit 0

--- a/tests/snapshots/command__after_help.snap
+++ b/tests/snapshots/command__after_help.snap
@@ -2,12 +2,12 @@
 source: tests/command.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_01b05459'
 [1m[4mUsage:[0m [1mmyprog[0m
 
 [1m[4mOptions:[0m
   [1m-h[0m, [1m--help[0m  Print help
 
 Does really amazing things for great people... but be careful with -R!
-EOF
+EOF_01b05459
 exit 0

--- a/tests/snapshots/command__arg.snap
+++ b/tests/snapshots/command__arg.snap
@@ -2,12 +2,12 @@
 source: tests/command.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_7b429414'
 [1m[4mUsage:[0m [1mmyprog[0m [OPTIONS]
 
 [1m[4mOptions:[0m
   [1m-d[0m <debug>             turns on debugging mode
   [1m-c[0m, [1m--config[0m <CONFIG>  Optionally sets a config file to use
   [1m-h[0m, [1m--help[0m             Print help
-EOF
+EOF_7b429414
 exit 0

--- a/tests/snapshots/command__author.snap
+++ b/tests/snapshots/command__author.snap
@@ -2,7 +2,7 @@
 source: tests/command.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_3527492b'
 myprog () Me, me@mymain.com - [1mmyprog[0m
-EOF
+EOF_3527492b
 exit 0

--- a/tests/snapshots/command__before_help.snap
+++ b/tests/snapshots/command__before_help.snap
@@ -2,7 +2,7 @@
 source: tests/command.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_b80c3b15'
 Some info I'd like to appear before the help info
 
 
@@ -10,5 +10,5 @@ Some info I'd like to appear before the help info
 
 [1m[4mOptions:[0m
   [1m-h[0m, [1m--help[0m  Print help
-EOF
+EOF_b80c3b15
 exit 0

--- a/tests/snapshots/command__before_long_help.snap
+++ b/tests/snapshots/command__before_long_help.snap
@@ -2,7 +2,7 @@
 source: tests/command.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_49562373'
 Some verbose and long info I'd like to appear before the help info
 
 
@@ -11,5 +11,5 @@ Some verbose and long info I'd like to appear before the help info
 [1m[4mOptions:[0m
   [1m-h[0m, [1m--help[0m
           Print help (see a summary with '-h')
-EOF
+EOF_49562373
 exit 0

--- a/tests/snapshots/command__bin_name.snap
+++ b/tests/snapshots/command__bin_name.snap
@@ -2,10 +2,10 @@
 source: tests/command.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_23365bfb'
 [1m[4mUsage:[0m [1mmy_binary[0m
 
 [1m[4mOptions:[0m
   [1m-h[0m, [1m--help[0m  Print help
-EOF
+EOF_23365bfb
 exit 0

--- a/tests/snapshots/command__color.snap
+++ b/tests/snapshots/command__color.snap
@@ -2,11 +2,11 @@
 source: tests/command.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_1c6068ef'
 [1m[31merror:[0m unexpected argument '[33m--cfg[0m' found
 
 [1m[4mUsage:[0m [1mmyprog[0m [OPTIONS]
 
 For more information, try '[1m--help[0m'.
-EOF
+EOF_1c6068ef
 exit 1

--- a/tests/snapshots/command__diable_help_flag-2.snap
+++ b/tests/snapshots/command__diable_help_flag-2.snap
@@ -2,10 +2,10 @@
 source: tests/command.rs
 expression: output2
 ---
-command cat <<'EOF'
+command cat <<'EOF_8a3a8edf'
 [1m[4mUsage:[0m [1mmyprog[0m
 
 [1m[4mOptions:[0m
       [1m--help[0m  Print version
-EOF
+EOF_8a3a8edf
 exit 0

--- a/tests/snapshots/command__diable_help_flag.snap
+++ b/tests/snapshots/command__diable_help_flag.snap
@@ -2,11 +2,11 @@
 source: tests/command.rs
 expression: output1
 ---
-command cat <<'EOF'
+command cat <<'EOF_1b8c26b8'
 [1m[31merror:[0m unexpected argument '[33m-h[0m' found
 
 [1m[4mUsage:[0m [1mmyprog[0m
 
 For more information, try '[1m--help[0m'.
-EOF
+EOF_1b8c26b8
 exit 1

--- a/tests/snapshots/command__diable_version_flag-2.snap
+++ b/tests/snapshots/command__diable_version_flag-2.snap
@@ -2,7 +2,7 @@
 source: tests/command.rs
 expression: output2
 ---
-command cat <<'EOF'
+command cat <<'EOF_29239711'
 myprog 1.0.0
-EOF
+EOF_29239711
 exit 0

--- a/tests/snapshots/command__diable_version_flag.snap
+++ b/tests/snapshots/command__diable_version_flag.snap
@@ -2,11 +2,11 @@
 source: tests/command.rs
 expression: output1
 ---
-command cat <<'EOF'
+command cat <<'EOF_e261705d'
 [1m[31merror:[0m unexpected argument '[33m-V[0m' found
 
 [1m[4mUsage:[0m [1mmyprog[0m
 
 For more information, try '[1m--help[0m'.
-EOF
+EOF_e261705d
 exit 1

--- a/tests/snapshots/command__disable_colored_help.snap
+++ b/tests/snapshots/command__disable_colored_help.snap
@@ -2,11 +2,11 @@
 source: tests/command.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_74924462'
 [1m[4mUsage:[0m [1mmyprog[0m [OPTIONS]
 
 [1m[4mOptions:[0m
       [1m--config[0m <cfg>  
   [1m-h[0m, [1m--help[0m          Print help
-EOF
+EOF_74924462
 exit 0

--- a/tests/snapshots/command__disable_help_subcommand.snap
+++ b/tests/snapshots/command__disable_help_subcommand.snap
@@ -2,11 +2,11 @@
 source: tests/command.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_5c7f48ec'
 [1m[31merror:[0m unrecognized subcommand '[33mhelp[0m'
 
 [1m[4mUsage:[0m [1mmyprog[0m [COMMAND]
 
 For more information, try '[1m--help[0m'.
-EOF
+EOF_5c7f48ec
 exit 1

--- a/tests/snapshots/command__display_name.snap
+++ b/tests/snapshots/command__display_name.snap
@@ -2,11 +2,11 @@
 source: tests/command.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_1c6068ef'
 [1m[31merror:[0m unexpected argument '[33m--cfg[0m' found
 
 [1m[4mUsage:[0m [1mmyprog[0m [OPTIONS]
 
 For more information, try '[1m--help[0m'.
-EOF
+EOF_1c6068ef
 exit 1

--- a/tests/snapshots/command__display_order.snap
+++ b/tests/snapshots/command__display_order.snap
@@ -2,7 +2,7 @@
 source: tests/command.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_b27eacc1'
 [1m[4mUsage:[0m [1mmyprog[0m [COMMAND]
 
 [1m[4mCommands:[0m
@@ -12,5 +12,5 @@ command cat <<'EOF'
 
 [1m[4mOptions:[0m
   [1m-h[0m, [1m--help[0m  Print help
-EOF
+EOF_b27eacc1
 exit 0

--- a/tests/snapshots/command__flatten_help.snap
+++ b/tests/snapshots/command__flatten_help.snap
@@ -2,7 +2,7 @@
 source: tests/command.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_f18541e8'
 [1m[4mUsage:[0m [1mmyprog[0m [arg1]
        [1mmyprog subcommand[0m [arg2]
        [1mmyprog subcommand nested[0m [OPTIONS]
@@ -37,5 +37,5 @@ another sub command
 [1m[4mmyprog help:[0m
 Print this message or the help of the given subcommand(s)
   [COMMAND]...  Print help for the subcommand(s)
-EOF
+EOF_f18541e8
 exit 0

--- a/tests/snapshots/command__group.snap
+++ b/tests/snapshots/command__group.snap
@@ -2,7 +2,7 @@
 source: tests/command.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_c1fb70eb'
 [1m[31merror:[0m the argument '[33m--major <major>[0m' cannot be used with:
   [33m--minor <minor>[0m
   [33m--patch <patch>[0m
@@ -10,5 +10,5 @@ command cat <<'EOF'
 [1m[4mUsage:[0m [1mcmd[0m <--set-ver <set-ver>|--major <major>|--minor <minor>|--patch <patch>>
 
 For more information, try '[1m--help[0m'.
-EOF
+EOF_c1fb70eb
 exit 1

--- a/tests/snapshots/command__help_expected.snap
+++ b/tests/snapshots/command__help_expected.snap
@@ -2,7 +2,7 @@
 source: tests/command.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_59c439b3'
 [1m[4mUsage:[0m [1mmyprog[0m [foo]
 
 [1m[4mArguments:[0m
@@ -10,5 +10,5 @@ command cat <<'EOF'
 
 [1m[4mOptions:[0m
   [1m-h[0m, [1m--help[0m  Print help
-EOF
+EOF_59c439b3
 exit 0

--- a/tests/snapshots/command__hide.snap
+++ b/tests/snapshots/command__hide.snap
@@ -2,7 +2,7 @@
 source: tests/command.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_94720ff7'
 [1m[4mUsage:[0m [1mmyprog[0m [COMMAND]
 
 [1m[4mCommands:[0m
@@ -11,5 +11,5 @@ command cat <<'EOF'
 
 [1m[4mOptions:[0m
   [1m-h[0m, [1m--help[0m  Print help
-EOF
+EOF_94720ff7
 exit 0

--- a/tests/snapshots/command__hide_possible_values.snap
+++ b/tests/snapshots/command__hide_possible_values.snap
@@ -2,11 +2,11 @@
 source: tests/command.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_84c9ada3'
 [1m[4mUsage:[0m [1mprog[0m [OPTIONS]
 
 [1m[4mOptions:[0m
       [1m--mode[0m <mode>  
   [1m-h[0m, [1m--help[0m         Print help
-EOF
+EOF_84c9ada3
 exit 0

--- a/tests/snapshots/command__infer_long_args_ambiguous.snap
+++ b/tests/snapshots/command__infer_long_args_ambiguous.snap
@@ -2,7 +2,7 @@
 source: tests/command.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_9ff163c4'
 [1m[31merror:[0m unexpected argument '[33m--te[0m' found
 
   [32mtip:[0m a similar argument exists: '[32m--temp[0m'
@@ -10,5 +10,5 @@ command cat <<'EOF'
 [1m[4mUsage:[0m [1mmyprog[0m [1m--temp[0m
 
 For more information, try '[1m--help[0m'.
-EOF
+EOF_9ff163c4
 exit 1

--- a/tests/snapshots/command__long_version.snap
+++ b/tests/snapshots/command__long_version.snap
@@ -2,10 +2,10 @@
 source: tests/command.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_7638c95c'
 myprog v0.1.24 commit: abcdef89726d
 revision: 123
 release: 2
 binary: myprog
-EOF
+EOF_7638c95c
 exit 0

--- a/tests/snapshots/command__max_term_width.snap
+++ b/tests/snapshots/command__max_term_width.snap
@@ -2,12 +2,12 @@
 source: tests/command.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_3f7c73ed'
 [1m[4mUsage:[0m [1mmyprog[0m [OPTIONS]
 
 [1m[4mOptions:[0m
       [1m--config[0m <cfg>  This is a very long help message that is longer than 80
                       characters and so will wrap
   [1m-h[0m, [1m--help[0m          Print help
-EOF
+EOF_3f7c73ed
 exit 0

--- a/tests/snapshots/command__next_display_order.snap
+++ b/tests/snapshots/command__next_display_order.snap
@@ -2,12 +2,12 @@
 source: tests/command.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_63925467'
 [1m[4mUsage:[0m [1mprog[0m [OPTIONS]
 
 [1m[4mOptions:[0m
   [1m-a[0m, [1m--airplane[0m <airplane>  I should be first!
   [1m-?[0m                         Alt help
   [1m-h[0m, [1m--help[0m                 Print help
-EOF
+EOF_63925467
 exit 0

--- a/tests/snapshots/command__next_help_heading.snap
+++ b/tests/snapshots/command__next_help_heading.snap
@@ -2,11 +2,11 @@
 source: tests/command.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_02f3f945'
 [1m[4mUsage:[0m [1mprog[0m [OPTIONS]
 
 [1m[4mOptions:[0m
       [1m--config[0m <cfg>  Some help text describing the --config arg
   [1m-h[0m, [1m--help[0m          Print help
-EOF
+EOF_02f3f945
 exit 0

--- a/tests/snapshots/command__next_line_help.snap
+++ b/tests/snapshots/command__next_line_help.snap
@@ -2,7 +2,7 @@
 source: tests/command.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_9eb35108'
 [1m[4mUsage:[0m [1mprog[0m [OPTIONS]
 
 [1m[4mOptions:[0m
@@ -12,5 +12,5 @@ command cat <<'EOF'
           on a line after the option
   [1m-h[0m, [1m--help[0m
           Print help
-EOF
+EOF_9eb35108
 exit 0

--- a/tests/snapshots/command__no_args.snap
+++ b/tests/snapshots/command__no_args.snap
@@ -2,10 +2,10 @@
 source: tests/command.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_ee8716d0'
 [1m[4mUsage:[0m [1mmyprog[0m
 
 [1m[4mOptions:[0m
   [1m-h[0m, [1m--help[0m  Print help
-EOF
+EOF_ee8716d0
 exit 0

--- a/tests/snapshots/command__override_help.snap
+++ b/tests/snapshots/command__override_help.snap
@@ -2,7 +2,7 @@
 source: tests/command.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_3624ca48'
 myapp v1.0
            Does awesome things
            (C) me@mail.com
@@ -18,5 +18,5 @@ myapp v1.0
            Commands:
            help             Print this message
            work             Do some work
-EOF
+EOF_3624ca48
 exit 0

--- a/tests/snapshots/command__override_usage.snap
+++ b/tests/snapshots/command__override_usage.snap
@@ -2,12 +2,12 @@
 source: tests/command.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_e8422258'
 [1m[4mUsage:[0m myapp -X [-a] [-b] <file>
                    myapp -Y [-c] <file1> <file2>
                    myapp -Z [-d|-e]
 
 [1m[4mOptions:[0m
   [1m-h[0m, [1m--help[0m  Print help
-EOF
+EOF_e8422258
 exit 0

--- a/tests/snapshots/command__propagate_version.snap
+++ b/tests/snapshots/command__propagate_version.snap
@@ -2,7 +2,7 @@
 source: tests/command.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_61e9d487'
 myprog-test v1.1
-EOF
+EOF_61e9d487
 exit 0

--- a/tests/snapshots/command__subcommand_help_heading.snap
+++ b/tests/snapshots/command__subcommand_help_heading.snap
@@ -2,7 +2,7 @@
 source: tests/command.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_11f6557c'
 [1m[4mUsage:[0m [1mmyprog[0m [COMMAND]
 
 [1m[4mThings:[0m
@@ -11,5 +11,5 @@ command cat <<'EOF'
 
 [1m[4mOptions:[0m
   [1m-h[0m, [1m--help[0m  Print help
-EOF
+EOF_11f6557c
 exit 0

--- a/tests/snapshots/command__subcommand_required.snap
+++ b/tests/snapshots/command__subcommand_required.snap
@@ -2,12 +2,12 @@
 source: tests/command.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_cba21254'
 [1m[31merror:[0m '[33mmyprog[0m' requires a subcommand but one was not provided
   [subcommands: [32mtest[0m, [32mhelp[0m]
 
 [1m[4mUsage:[0m [1mmyprog[0m <COMMAND>
 
 For more information, try '[1m--help[0m'.
-EOF
+EOF_cba21254
 exit 1

--- a/tests/snapshots/command__subcommand_value_name.snap
+++ b/tests/snapshots/command__subcommand_value_name.snap
@@ -2,7 +2,7 @@
 source: tests/command.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_7ef26a48'
 [1m[4mUsage:[0m [1mmyprog[0m [THING]
 
 [1m[4mCommands:[0m
@@ -11,5 +11,5 @@ command cat <<'EOF'
 
 [1m[4mOptions:[0m
   [1m-h[0m, [1m--help[0m  Print help
-EOF
+EOF_7ef26a48
 exit 0

--- a/tests/snapshots/command__template.snap
+++ b/tests/snapshots/command__template.snap
@@ -2,12 +2,12 @@
 source: tests/command.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_c99dd66c'
 myprog 
 
 [1m[4mUsage:[0m [1mmyprog[0m
 
 [1m[4mOptions:[0m
   [1m-h[0m, [1m--help[0m  Print help
-EOF
+EOF_c99dd66c
 exit 0

--- a/tests/snapshots/command__term_width.snap
+++ b/tests/snapshots/command__term_width.snap
@@ -2,12 +2,12 @@
 source: tests/command.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_3f7c73ed'
 [1m[4mUsage:[0m [1mmyprog[0m [OPTIONS]
 
 [1m[4mOptions:[0m
       [1m--config[0m <cfg>  This is a very long help message that is longer than 80
                       characters and so will wrap
   [1m-h[0m, [1m--help[0m          Print help
-EOF
+EOF_3f7c73ed
 exit 0

--- a/tests/snapshots/command__version.snap
+++ b/tests/snapshots/command__version.snap
@@ -2,7 +2,7 @@
 source: tests/command.rs
 expression: output
 ---
-command cat <<'EOF'
+command cat <<'EOF_72ffdf99'
 myprog v0.1.24
-EOF
+EOF_72ffdf99
 exit 0


### PR DESCRIPTION
## Summary
- avoid delimiter clashes in CatCmd fmt using a CRC32 hash
- update all snapshots with the new `EOF_<hex>` delimiter
- test CatCmd with messages that contain `EOF`

## Testing
- `cargo build`
- `INSTA_UPDATE=always cargo test --no-fail-fast` *(fails: test_panic::test_panic_zsh_expects, test_show_usage::shell_show_usage_zsh_json_expects, test_show_usage::shell_show_usage_zsh_toml_expects, test_show_usage::shell_show_usage_zsh_yaml_expects, test_spec_file::test_spec_file_zsh_json_expects, test_spec_file::test_spec_file_zsh_toml_expects, test_spec_file::test_spec_file_zsh_yaml_expects, test_spec_stdin_heredoc::test_spec_stdin_heredoc_zsh_expects, test_spec_stdin_redirect::test_spec_stdin_redirect_zsh_json_expects, test_spec_stdin_redirect::test_spec_stdin_redirect_zsh_toml_expects, test_spec_stdin_redirect::test_spec_stdin_redirect_zsh_yaml_expects)*

------
https://chatgpt.com/codex/tasks/task_e_684fab185a4c83298acacb4da1db91b3