### PR TITLE
Add fish shell support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,17 @@ echo "mode: $claptrap_mode"
 echo "protocol: $claptrap_protocol"
 ```
 
+`myapp.fish`:
+
+```fish
+#!/usr/bin/env fish
+
+eval (claptrap --shell fish --spec myapp.toml -- $argv | string collect)
+
+echo "mode: $claptrap_mode"
+echo "protocol: $claptrap_protocol"
+```
+
 `myapp.toml`:
 
 ```toml

--- a/docs/src/content/docs/getting-started/index.mdx
+++ b/docs/src/content/docs/getting-started/index.mdx
@@ -38,6 +38,17 @@ echo "mode: $claptrap_mode"
 echo "protocol: $claptrap_protocol"
 ```
 
+Use Claptrap in a fish script:
+
+```fish
+#!/usr/bin/env fish
+
+eval (claptrap --shell fish --spec spec.toml -- $argv | string collect)
+
+echo "mode: $claptrap_mode"
+echo "protocol: $claptrap_protocol"
+```
+
 Run your script:
 
 ```bash

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,5 @@
 use clap::{Parser, Subcommand};
+use claptrap::shell::Shell;
 use std::ffi::OsString;
 use std::fmt::{Display, Formatter};
 use std::path::PathBuf;
@@ -17,6 +18,10 @@ pub struct Cli {
     /// Do not suppress panic messages
     #[arg(long)]
     pub show_panic: bool,
+
+    /// The shell to format output for
+    #[arg(long, value_enum, env = "CLAPTRAP_SHELL", default_value_t = Shell::Bash)]
+    pub shell: Shell,
 
     #[command(subcommand)]
     pub command: Option<SubCommand>,
@@ -64,21 +69,6 @@ pub enum SubCommand {
         #[arg(short, long, value_name = "FILE")]
         output: Option<PathBuf>,
     },
-}
-
-/// Shell with template script available.
-#[derive(clap::ValueEnum, Debug, Clone)]
-#[non_exhaustive]
-pub enum Shell {
-    /// Bourne Again `SHell` (bash)
-    Bash,
-    /// Friendly Interactive `SHell` (fish)
-    Fish,
-    /// `PowerShell`
-    #[allow(clippy::enum_variant_names)]
-    PowerShell,
-    /// Z `SHell` (zsh)
-    Zsh,
 }
 
 /// Spec file format.

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,6 +19,12 @@ impl Display for Error {
     }
 }
 
+impl Error {
+    pub fn for_shell(&self, shell: claptrap::shell::Shell) -> String {
+        self.0.for_shell(shell)
+    }
+}
+
 impl From<anyhow::Error> for Error {
     fn from(err: anyhow::Error) -> Self {
         Self(Output::Cat(CatCmd::new(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub mod arg_group;
 pub mod command;
 pub mod num_args;
 pub mod output;
+pub mod shell;
 
 /// Parse the provided arguments and generate output.
 ///

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -1,0 +1,13 @@
+#[derive(clap::ValueEnum, Debug, Clone, Copy)]
+#[non_exhaustive]
+pub enum Shell {
+    /// Bourne Again `SHell` (bash)
+    Bash,
+    /// Friendly Interactive `SHell` (fish)
+    Fish,
+    /// `PowerShell`
+    #[allow(clippy::enum_variant_names)]
+    PowerShell,
+    /// Z `SHell` (zsh)
+    Zsh,
+}

--- a/templates/fish_template.sh
+++ b/templates/fish_template.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env fish
+
+if not type -q claptrap
+    echo "claptrap command not found. Please install it first, see https://claptrap.cli.rs for instructions."
+    exit 1
+end
+
+eval (claptrap --shell fish --spec spec.toml -- $argv | string collect)

--- a/tests/resources/shell/fish/file.sh
+++ b/tests/resources/shell/fish/file.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env fish
+
+eval ( $CLAPTRAP_BIN --shell fish --spec $CLAPTRAP_SPEC -- $argv | string collect )
+
+echo "mode: $claptrap_mode"
+echo "protocol: $claptrap_protocol"

--- a/tests/resources/shell/fish/panic.sh
+++ b/tests/resources/shell/fish/panic.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env fish
+
+set spec "name = \"myapp\"
+[args]
+# this wil cause clap to panic
+mode = { index = 2 }
+"
+eval (printf "%s" "$spec" | $CLAPTRAP_BIN --shell fish --spec - -- $argv | string collect)

--- a/tests/resources/shell/fish/stdin_heredoc.sh
+++ b/tests/resources/shell/fish/stdin_heredoc.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env fish
+
+set spec "name = \"myapp\"
+version = \"0.1.0\"
+[args]
+mode = { short = \"m\", long = \"mode\" }
+protocol = { short = \"p\", long = \"protocol\" }
+"
+eval (printf "%s" "$spec" | $CLAPTRAP_BIN --shell fish --spec - -- $argv | string collect)
+
+echo "mode: $claptrap_mode"
+echo "protocol: $claptrap_protocol"

--- a/tests/resources/shell/fish/stdin_redirect.sh
+++ b/tests/resources/shell/fish/stdin_redirect.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env fish
+
+eval ( $CLAPTRAP_BIN --shell fish --spec-format $CLAPTRAP_SPEC_FORMAT --spec - < $CLAPTRAP_SPEC -- $argv | string collect )
+
+echo "mode: $claptrap_mode"
+echo "protocol: $claptrap_protocol"

--- a/tests/shell.rs
+++ b/tests/shell.rs
@@ -4,7 +4,7 @@ use test_case::test_matrix;
 
 const CLAPTRAP_BIN: &str = env!("CARGO_BIN_EXE_claptrap");
 
-#[test_matrix(["bash", "zsh"], ["yaml", "json", "toml"]; "shell_show_usage")]
+#[test_matrix(["bash", "zsh", "fish"], ["yaml", "json", "toml"]; "shell_show_usage")]
 fn test_show_usage(shell: &str, format: &str) {
     let output = std::process::Command::new(format!("tests/resources/shell/{shell}/file.sh"))
         .env("CLAPTRAP_BIN", CLAPTRAP_BIN)
@@ -21,7 +21,7 @@ fn test_show_usage(shell: &str, format: &str) {
     );
 }
 
-#[test_matrix(["bash", "zsh"], ["yaml", "json", "toml"]; "test_spec_file")]
+#[test_matrix(["bash", "zsh", "fish"], ["yaml", "json", "toml"]; "test_spec_file")]
 fn test_spec_file(shell: &str, format: &str) {
     let output = std::process::Command::new(format!("tests/resources/shell/{shell}/file.sh"))
         .env("CLAPTRAP_BIN", CLAPTRAP_BIN)
@@ -42,7 +42,7 @@ fn test_spec_file(shell: &str, format: &str) {
     );
 }
 
-#[test_matrix(["bash", "zsh"], ["yaml", "json", "toml"]; "test_spec_stdin_redirect")]
+#[test_matrix(["bash", "zsh", "fish"], ["yaml", "json", "toml"]; "test_spec_stdin_redirect")]
 fn test_spec_stdin_redirect(shell: &str, format: &str) {
     let output =
         std::process::Command::new(format!("tests/resources/shell/{shell}/stdin_redirect.sh"))
@@ -65,7 +65,7 @@ fn test_spec_stdin_redirect(shell: &str, format: &str) {
     );
 }
 
-#[test_matrix(["bash", "zsh"]; "test_spec_stdin_heredoc")]
+#[test_matrix(["bash", "zsh", "fish"]; "test_spec_stdin_heredoc")]
 fn test_spec_stdin_heredoc(shell: &str) {
     let output =
         std::process::Command::new(format!("tests/resources/shell/{shell}/stdin_heredoc.sh"))
@@ -83,7 +83,7 @@ fn test_spec_stdin_heredoc(shell: &str) {
     );
 }
 
-#[test_matrix(["bash", "zsh"]; "test_panic")]
+#[test_matrix(["bash", "zsh", "fish"]; "test_panic")]
 fn test_panic(shell: &str) {
     let output = std::process::Command::new(format!("tests/resources/shell/{shell}/panic.sh"))
         .env("CLAPTRAP_BIN", CLAPTRAP_BIN)

--- a/tests/snapshots/shell__panic-3.snap
+++ b/tests/snapshots/shell__panic-3.snap
@@ -1,0 +1,5 @@
+---
+source: tests/shell.rs
+expression: "String::from_utf8_lossy(&output.stdout)"
+---
+Found positional argument whose index is 2 but there are only 1 positional arguments defined

--- a/tests/snapshots/shell__test_show_usage_fish_json.snap
+++ b/tests/snapshots/shell__test_show_usage_fish_json.snap
@@ -1,0 +1,11 @@
+---
+source: tests/shell.rs
+expression: "String::from_utf8_lossy(&output.stdout)"
+---
+[1m[4mUsage:[0m [1mmyapp[0m [OPTIONS]
+
+[1m[4mOptions:[0m
+  [1m-m[0m, [1m--mode[0m <mode>          
+  [1m-p[0m, [1m--protocol[0m <protocol>  
+  [1m-h[0m, [1m--help[0m                 Print help
+  [1m-V[0m, [1m--version[0m              Print version

--- a/tests/snapshots/shell__test_show_usage_fish_toml.snap
+++ b/tests/snapshots/shell__test_show_usage_fish_toml.snap
@@ -1,0 +1,11 @@
+---
+source: tests/shell.rs
+expression: "String::from_utf8_lossy(&output.stdout)"
+---
+[1m[4mUsage:[0m [1mmyapp[0m [OPTIONS]
+
+[1m[4mOptions:[0m
+  [1m-m[0m, [1m--mode[0m <mode>          
+  [1m-p[0m, [1m--protocol[0m <protocol>  
+  [1m-h[0m, [1m--help[0m                 Print help
+  [1m-V[0m, [1m--version[0m              Print version

--- a/tests/snapshots/shell__test_show_usage_fish_yaml.snap
+++ b/tests/snapshots/shell__test_show_usage_fish_yaml.snap
@@ -1,0 +1,11 @@
+---
+source: tests/shell.rs
+expression: "String::from_utf8_lossy(&output.stdout)"
+---
+[1m[4mUsage:[0m [1mmyapp[0m [OPTIONS]
+
+[1m[4mOptions:[0m
+  [1m-m[0m, [1m--mode[0m <mode>          
+  [1m-p[0m, [1m--protocol[0m <protocol>  
+  [1m-h[0m, [1m--help[0m                 Print help
+  [1m-V[0m, [1m--version[0m              Print version

--- a/tests/snapshots/shell__test_spec_file_fish_json.snap
+++ b/tests/snapshots/shell__test_spec_file_fish_json.snap
@@ -1,0 +1,6 @@
+---
+source: tests/shell.rs
+expression: "String::from_utf8_lossy(&output.stdout)"
+---
+mode: stream
+protocol: udp

--- a/tests/snapshots/shell__test_spec_file_fish_toml.snap
+++ b/tests/snapshots/shell__test_spec_file_fish_toml.snap
@@ -1,0 +1,6 @@
+---
+source: tests/shell.rs
+expression: "String::from_utf8_lossy(&output.stdout)"
+---
+mode: stream
+protocol: udp

--- a/tests/snapshots/shell__test_spec_file_fish_yaml.snap
+++ b/tests/snapshots/shell__test_spec_file_fish_yaml.snap
@@ -1,0 +1,6 @@
+---
+source: tests/shell.rs
+expression: "String::from_utf8_lossy(&output.stdout)"
+---
+mode: stream
+protocol: udp

--- a/tests/snapshots/shell__test_spec_stdin_heredoc_fish.snap
+++ b/tests/snapshots/shell__test_spec_stdin_heredoc_fish.snap
@@ -1,0 +1,6 @@
+---
+source: tests/shell.rs
+expression: "String::from_utf8_lossy(&output.stdout)"
+---
+mode: stream
+protocol: udp

--- a/tests/snapshots/shell__test_spec_stdin_redirect_fish_json.snap
+++ b/tests/snapshots/shell__test_spec_stdin_redirect_fish_json.snap
@@ -1,0 +1,6 @@
+---
+source: tests/shell.rs
+expression: "String::from_utf8_lossy(&output.stdout)"
+---
+mode: stream
+protocol: udp

--- a/tests/snapshots/shell__test_spec_stdin_redirect_fish_toml.snap
+++ b/tests/snapshots/shell__test_spec_stdin_redirect_fish_toml.snap
@@ -1,0 +1,6 @@
+---
+source: tests/shell.rs
+expression: "String::from_utf8_lossy(&output.stdout)"
+---
+mode: stream
+protocol: udp

--- a/tests/snapshots/shell__test_spec_stdin_redirect_fish_yaml.snap
+++ b/tests/snapshots/shell__test_spec_stdin_redirect_fish_yaml.snap
@@ -1,0 +1,6 @@
+---
+source: tests/shell.rs
+expression: "String::from_utf8_lossy(&output.stdout)"
+---
+mode: stream
+protocol: udp


### PR DESCRIPTION
## Summary
- support fish shell output and template
- update CLI with `--shell` option
- add fish examples in docs and README
- add fish shell integration tests and snapshots

## Testing
- `cargo clippy --workspace --all-features --tests -- -Dwarnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6850aea1b04883299023d063f580d1a6