### PR TITLE
Remove strum dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "strum",
  "test-case",
  "toml",
 ]
@@ -340,12 +339,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
-
-[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -417,28 +410,6 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
-name = "strum"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
-dependencies = [
- "strum_macros",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn",
-]
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ itertools = "0.14.0"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = { version = "1.0.140", features = ["preserve_order"] }
 serde_yaml = { version = "=0.9.33", features = [] }
-strum = { version = "0.27.1", features = ["derive"] }
 toml = { version = "0.8.22", features = ["preserve_order"] }
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary
- drop strum from the dependency list
- implement `TypedValueParser` parsing with serde

## Testing
- `cargo fmt --all`
- `cargo clippy --workspace --all-features --tests -- -Dwarnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6856bc14ec7883299f0839fbc152b4ab