### PR TITLE
Add conditional Arg requirements

### DIFF
--- a/docs/src/content/docs/getting-started/index.mdx
+++ b/docs/src/content/docs/getting-started/index.mdx
@@ -47,3 +47,21 @@ protocol: http
 ```
 
 That's it! You're now ready to clap 👏 and trap 🪤 your arguments!
+
+## Conditional Requirements
+
+Arguments can depend on the value of other arguments using the `required-if-eq`
+and `requires-if` options:
+
+```toml
+name = "myapp"
+
+[args]
+mode = { long = "mode", action = "set" }
+out  = { long = "out",  action = "set", required-if-eq = { arg = "mode", value = "debug" } }
+config = { long = "config", action = "set", requires-if = { value = "prod", arg = "cert" } }
+cert   = { long = "cert", action = "set" }
+```
+
+With this configuration `--out <val>` is required when `--mode debug` and
+`--cert <val>` is required when `--config prod`.

--- a/docs/src/content/docs/reference/supported.mdx
+++ b/docs/src/content/docs/reference/supported.mdx
@@ -141,11 +141,11 @@ APIs in `claptrap`.
 | [`required_unless_present`](https://docs.rs/clap/latest/clap/struct.Arg.html#method.required_unless_present) | ✅ | |
 | [`required_unless_present_all`](https://docs.rs/clap/latest/clap/struct.Arg.html#method.required_unless_present_all) | ✅ | |
 | [`required_unless_present_any`](https://docs.rs/clap/latest/clap/struct.Arg.html#method.required_unless_present_any) | ✅ | |
-| [`required_if_eq`](https://docs.rs/clap/latest/clap/struct.Arg.html#method.required_if_eq) | ❌ | |
-| [`required_if_eq_any`](https://docs.rs/clap/latest/clap/struct.Arg.html#method.required_if_eq_any) | ❌ | |
-| [`required_if_eq_all`](https://docs.rs/clap/latest/clap/struct.Arg.html#method.required_if_eq_all) | ❌ | |
-| [`requires_if`](https://docs.rs/clap/latest/clap/struct.Arg.html#method.requires_if) | ❌ | |
-| [`requires_ifs`](https://docs.rs/clap/latest/clap/struct.Arg.html#method.requires_ifs) | ❌ | |
+| [`required_if_eq`](https://docs.rs/clap/latest/clap/struct.Arg.html#method.required_if_eq) | ✅ | |
+| [`required_if_eq_any`](https://docs.rs/clap/latest/clap/struct.Arg.html#method.required_if_eq_any) | ✅ | |
+| [`required_if_eq_all`](https://docs.rs/clap/latest/clap/struct.Arg.html#method.required_if_eq_all) | ✅ | |
+| [`requires_if`](https://docs.rs/clap/latest/clap/struct.Arg.html#method.requires_if) | ✅ | |
+| [`requires_ifs`](https://docs.rs/clap/latest/clap/struct.Arg.html#method.requires_ifs) | ✅ | |
 | [`conflicts_with`](https://docs.rs/clap/latest/clap/struct.Arg.html#method.conflicts_with) | ✅ | |
 | [`conflicts_with_all`](https://docs.rs/clap/latest/clap/struct.Arg.html#method.conflicts_with_all) | ✅ | |
 | [`overrides_with`](https://docs.rs/clap/latest/clap/struct.Arg.html#method.overrides_with) | ✅ | |

--- a/tests/arg.rs
+++ b/tests/arg.rs
@@ -1275,11 +1275,123 @@ fn test_required_unless_present_any() {
     insta::assert_snapshot!(output2);
 }
 
-// TODO: required_if_eq
-// TODO: required_if_eq_any
-// TODO: required_if_eq_all
-// TODO: requires_if
-// TODO: requires_ifs
+#[test]
+fn test_required_if_eq() {
+    let app: Command = toml::from_str(
+        r#"
+            name = "prog"
+            [args]
+            mode = { long = "mode", action = "set" }
+            out = { long = "out", action = "set", required-if-eq = { arg = "mode", value = "debug" } }
+        "#,
+    )
+    .unwrap();
+
+    let input1 = "--mode release";
+    let args1: Vec<OsString> = input1.split(' ').map(OsString::from).collect();
+    let output1 = parse(app.clone(), args1);
+    insta::assert_snapshot!(output1);
+
+    let input2 = "--mode debug";
+    let args2: Vec<OsString> = input2.split(' ').map(OsString::from).collect();
+    let output2 = parse(app, args2);
+    insta::assert_snapshot!(output2);
+}
+
+#[test]
+fn test_required_if_eq_any() {
+    let app: Command = toml::from_str(
+        r#"
+            name = "prog"
+            [args]
+            mode = { long = "mode", action = "set" }
+            level = { long = "level", action = "set" }
+            out = { long = "out", action = "set", required-if-eq-any = [ { arg = "mode", value = "debug" }, { arg = "level", value = "verbose" } ] }
+        "#,
+    )
+    .unwrap();
+
+    let input1 = "--mode debug";
+    let args1: Vec<OsString> = input1.split(' ').map(OsString::from).collect();
+    let output1 = parse(app.clone(), args1);
+    insta::assert_snapshot!(output1);
+
+    let input2 = "--mode release --level info";
+    let args2: Vec<OsString> = input2.split(' ').map(OsString::from).collect();
+    let output2 = parse(app, args2);
+    insta::assert_snapshot!(output2);
+}
+
+#[test]
+fn test_required_if_eq_all() {
+    let app: Command = toml::from_str(
+        r#"
+            name = "prog"
+            [args]
+            mode = { long = "mode", action = "set" }
+            level = { long = "level", action = "set" }
+            out = { long = "out", action = "set", required-if-eq-all = [ { arg = "mode", value = "debug" }, { arg = "level", value = "verbose" } ] }
+        "#,
+    )
+    .unwrap();
+
+    let input1 = "--mode debug --level verbose";
+    let args1: Vec<OsString> = input1.split(' ').map(OsString::from).collect();
+    let output1 = parse(app.clone(), args1);
+    insta::assert_snapshot!(output1);
+
+    let input2 = "--mode debug";
+    let args2: Vec<OsString> = input2.split(' ').map(OsString::from).collect();
+    let output2 = parse(app, args2);
+    insta::assert_snapshot!(output2);
+}
+
+#[test]
+fn test_requires_if() {
+    let app: Command = toml::from_str(
+        r#"
+            name = "prog"
+            [args]
+            config = { long = "config", action = "set", requires-if = { value = "prod", arg = "cert" } }
+            cert = { long = "cert", action = "set" }
+        "#,
+    )
+    .unwrap();
+
+    let input1 = "--config prod";
+    let args1: Vec<OsString> = input1.split(' ').map(OsString::from).collect();
+    let output1 = parse(app.clone(), args1);
+    insta::assert_snapshot!(output1);
+
+    let input2 = "--config test";
+    let args2: Vec<OsString> = input2.split(' ').map(OsString::from).collect();
+    let output2 = parse(app, args2);
+    insta::assert_snapshot!(output2);
+}
+
+#[test]
+fn test_requires_ifs() {
+    let app: Command = toml::from_str(
+        r#"
+            name = "prog"
+            [args]
+            config = { long = "config", action = "set", requires-ifs = [ { value = "prod", arg = "cert" }, { value = "debug", arg = "log" } ] }
+            cert = { long = "cert", action = "set" }
+            log = { long = "log", action = "set" }
+        "#,
+    )
+    .unwrap();
+
+    let input1 = "--config prod";
+    let args1: Vec<OsString> = input1.split(' ').map(OsString::from).collect();
+    let output1 = parse(app.clone(), args1);
+    insta::assert_snapshot!(output1);
+
+    let input2 = "--config prod --cert file";
+    let args2: Vec<OsString> = input2.split(' ').map(OsString::from).collect();
+    let output2 = parse(app, args2);
+    insta::assert_snapshot!(output2);
+}
 
 #[test]
 fn test_conflicts_with() {

--- a/tests/snapshots/arg__required_if_eq-2.snap
+++ b/tests/snapshots/arg__required_if_eq-2.snap
@@ -1,0 +1,13 @@
+---
+source: tests/arg.rs
+expression: output2
+---
+command cat <<'EOF_e50ac9c2'
+[1m[31merror:[0m the following required arguments were not provided:
+  [32m--out <out>[0m
+
+[1m[4mUsage:[0m [1mprog[0m [1m--mode[0m <mode> [1m--out[0m <out>
+
+For more information, try '[1m--help[0m'.
+EOF_e50ac9c2
+exit 1

--- a/tests/snapshots/arg__required_if_eq.snap
+++ b/tests/snapshots/arg__required_if_eq.snap
@@ -1,0 +1,5 @@
+---
+source: tests/arg.rs
+expression: output1
+---
+claptrap_mode='release'

--- a/tests/snapshots/arg__required_if_eq_all-2.snap
+++ b/tests/snapshots/arg__required_if_eq_all-2.snap
@@ -1,0 +1,5 @@
+---
+source: tests/arg.rs
+expression: output2
+---
+claptrap_mode='debug'

--- a/tests/snapshots/arg__required_if_eq_all.snap
+++ b/tests/snapshots/arg__required_if_eq_all.snap
@@ -1,0 +1,13 @@
+---
+source: tests/arg.rs
+expression: output1
+---
+command cat <<'EOF_8d12a6ea'
+[1m[31merror:[0m the following required arguments were not provided:
+  [32m--out <out>[0m
+
+[1m[4mUsage:[0m [1mprog[0m [1m--mode[0m <mode> [1m--level[0m <level> [1m--out[0m <out>
+
+For more information, try '[1m--help[0m'.
+EOF_8d12a6ea
+exit 1

--- a/tests/snapshots/arg__required_if_eq_any-2.snap
+++ b/tests/snapshots/arg__required_if_eq_any-2.snap
@@ -1,0 +1,6 @@
+---
+source: tests/arg.rs
+expression: output2
+---
+claptrap_mode='release'
+claptrap_level='info'

--- a/tests/snapshots/arg__required_if_eq_any.snap
+++ b/tests/snapshots/arg__required_if_eq_any.snap
@@ -1,0 +1,13 @@
+---
+source: tests/arg.rs
+expression: output1
+---
+command cat <<'EOF_e50ac9c2'
+[1m[31merror:[0m the following required arguments were not provided:
+  [32m--out <out>[0m
+
+[1m[4mUsage:[0m [1mprog[0m [1m--mode[0m <mode> [1m--out[0m <out>
+
+For more information, try '[1m--help[0m'.
+EOF_e50ac9c2
+exit 1

--- a/tests/snapshots/arg__requires_if-2.snap
+++ b/tests/snapshots/arg__requires_if-2.snap
@@ -1,0 +1,5 @@
+---
+source: tests/arg.rs
+expression: output2
+---
+claptrap_config='test'

--- a/tests/snapshots/arg__requires_if.snap
+++ b/tests/snapshots/arg__requires_if.snap
@@ -1,0 +1,13 @@
+---
+source: tests/arg.rs
+expression: output1
+---
+command cat <<'EOF_83e997ca'
+[1m[31merror:[0m the following required arguments were not provided:
+  [32m--cert <cert>[0m
+
+[1m[4mUsage:[0m [1mprog[0m [1m--cert[0m <cert> [1m--config[0m <config>
+
+For more information, try '[1m--help[0m'.
+EOF_83e997ca
+exit 1

--- a/tests/snapshots/arg__requires_ifs-2.snap
+++ b/tests/snapshots/arg__requires_ifs-2.snap
@@ -1,0 +1,6 @@
+---
+source: tests/arg.rs
+expression: output2
+---
+claptrap_config='prod'
+claptrap_cert='file'

--- a/tests/snapshots/arg__requires_ifs.snap
+++ b/tests/snapshots/arg__requires_ifs.snap
@@ -1,0 +1,13 @@
+---
+source: tests/arg.rs
+expression: output1
+---
+command cat <<'EOF_83e997ca'
+[1m[31merror:[0m the following required arguments were not provided:
+  [32m--cert <cert>[0m
+
+[1m[4mUsage:[0m [1mprog[0m [1m--cert[0m <cert> [1m--config[0m <config>
+
+For more information, try '[1m--help[0m'.
+EOF_83e997ca
+exit 1


### PR DESCRIPTION
## Summary
- implement `required_if_eq`, `required_if_eq_any`, `required_if_eq_all`, `requires_if` and `requires_ifs`
- document support for the new setters
- add docs on conditional requirements
- test new clap features

## Testing
- `cargo test`
- `cargo clippy --workspace --all-features --tests -- -Dwarnings`


------
https://chatgpt.com/codex/tasks/task_e_6856cc5e43f883298d6a280f1e12060b