### PR TITLE
Add subcommand variable

### DIFF
--- a/examples/git/README.md
+++ b/examples/git/README.md
@@ -28,6 +28,7 @@ Clone a repository:
 ```shell
 ./git.sh clone https://github.com/fujiapple852/claptrap.git
 claptrap_clone_REMOTE: https://github.com/fujiapple852/claptrap.git
+claptrap_subcommand: clone
 ```
 
 Diff between two commits for a specific path:

--- a/examples/pacman/README.md
+++ b/examples/pacman/README.md
@@ -41,6 +41,7 @@ Query a package:
 ```shell
 ./pacman.sh query -s claptrap
 claptrap_query_search[0]: claptrap
+claptrap_subcommand: query
 ```
 
 Show help for the `sync` subcommand:
@@ -64,6 +65,7 @@ Sync a package:
 
 ```shell
 /pacman.sh -S claptrap
+claptrap_subcommand: sync
 claptrap_sync_info: false
 claptrap_sync_package[0]: claptrap
 ```
@@ -72,6 +74,7 @@ Show sync info for some packages:
 
 ```shell
 ./pacman.sh --sync -i claptrap trippy
+claptrap_subcommand: sync
 claptrap_sync_info: true
 claptrap_sync_package[0]: claptrap
 claptrap_sync_package[1]: trippy

--- a/tests/snapshots/command__alias.snap
+++ b/tests/snapshots/command__alias.snap
@@ -2,4 +2,5 @@
 source: tests/command.rs
 expression: output
 ---
+claptrap_subcommand='test'
 claptrap_test_search='true'

--- a/tests/snapshots/command__aliases.snap
+++ b/tests/snapshots/command__aliases.snap
@@ -2,4 +2,4 @@
 source: tests/command.rs
 expression: output
 ---
-
+claptrap_subcommand='test'

--- a/tests/snapshots/command__allow_external_subcommands.snap
+++ b/tests/snapshots/command__allow_external_subcommands.snap
@@ -2,4 +2,4 @@
 source: tests/command.rs
 expression: output
 ---
-
+claptrap_subcommand='subcmd'

--- a/tests/snapshots/command__args_conflicts_with_subcommands.snap
+++ b/tests/snapshots/command__args_conflicts_with_subcommands.snap
@@ -2,4 +2,4 @@
 source: tests/command.rs
 expression: output
 ---
-
+claptrap_subcommand='test'

--- a/tests/snapshots/command__external_subcommand_value_parser.snap
+++ b/tests/snapshots/command__external_subcommand_value_parser.snap
@@ -2,4 +2,4 @@
 source: tests/command.rs
 expression: output
 ---
-
+claptrap_subcommand='subcmd'

--- a/tests/snapshots/command__infer_subcommands.snap
+++ b/tests/snapshots/command__infer_subcommands.snap
@@ -2,4 +2,5 @@
 source: tests/command.rs
 expression: output
 ---
+claptrap_subcommand='test'
 claptrap_test_arg1='true'

--- a/tests/snapshots/command__long_flag.snap
+++ b/tests/snapshots/command__long_flag.snap
@@ -2,4 +2,5 @@
 source: tests/command.rs
 expression: output
 ---
+claptrap_subcommand='sync'
 claptrap_sync_search='true'

--- a/tests/snapshots/command__long_flag_alias.snap
+++ b/tests/snapshots/command__long_flag_alias.snap
@@ -2,4 +2,5 @@
 source: tests/command.rs
 expression: output
 ---
+claptrap_subcommand='test'
 claptrap_test_search='true'

--- a/tests/snapshots/command__long_flag_aliases.snap
+++ b/tests/snapshots/command__long_flag_aliases.snap
@@ -2,4 +2,4 @@
 source: tests/command.rs
 expression: output
 ---
-
+claptrap_subcommand='test'

--- a/tests/snapshots/command__short_flag.snap
+++ b/tests/snapshots/command__short_flag.snap
@@ -2,4 +2,5 @@
 source: tests/command.rs
 expression: output
 ---
+claptrap_subcommand='sync'
 claptrap_sync_search='true'

--- a/tests/snapshots/command__short_flag_alias.snap
+++ b/tests/snapshots/command__short_flag_alias.snap
@@ -2,4 +2,5 @@
 source: tests/command.rs
 expression: output
 ---
+claptrap_subcommand='test'
 claptrap_test_search='true'

--- a/tests/snapshots/command__short_flag_aliases.snap
+++ b/tests/snapshots/command__short_flag_aliases.snap
@@ -2,4 +2,4 @@
 source: tests/command.rs
 expression: output
 ---
-
+claptrap_subcommand='test'

--- a/tests/snapshots/command__subcommand.snap
+++ b/tests/snapshots/command__subcommand.snap
@@ -2,4 +2,5 @@
 source: tests/command.rs
 expression: output
 ---
+claptrap_subcommand='subcommand nested'
 claptrap_subcommand_nested_arg3='value'

--- a/tests/snapshots/command__subcommand_many.snap
+++ b/tests/snapshots/command__subcommand_many.snap
@@ -2,4 +2,5 @@
 source: tests/command.rs
 expression: output
 ---
+claptrap_subcommand='subcommand nested'
 claptrap_subcommand_nested_arg3=('one' 'two')

--- a/tests/snapshots/command__subcommand_precedence_over_arg.snap
+++ b/tests/snapshots/command__subcommand_precedence_over_arg.snap
@@ -2,4 +2,5 @@
 source: tests/command.rs
 expression: output
 ---
+claptrap_subcommand='sub'
 claptrap_arg=('1' '2' '3')

--- a/tests/snapshots/command__visible_alias.snap
+++ b/tests/snapshots/command__visible_alias.snap
@@ -2,4 +2,5 @@
 source: tests/command.rs
 expression: output
 ---
+claptrap_subcommand='test'
 claptrap_test_input='file.txt'

--- a/tests/snapshots/command__visible_aliases.snap
+++ b/tests/snapshots/command__visible_aliases.snap
@@ -2,4 +2,5 @@
 source: tests/command.rs
 expression: output
 ---
+claptrap_subcommand='test'
 claptrap_test_input='config.txt'

--- a/tests/snapshots/command__visible_long_flag_alias.snap
+++ b/tests/snapshots/command__visible_long_flag_alias.snap
@@ -2,4 +2,5 @@
 source: tests/command.rs
 expression: output
 ---
+claptrap_subcommand='test'
 claptrap_test_input='file.txt'

--- a/tests/snapshots/command__visible_long_flag_aliases.snap
+++ b/tests/snapshots/command__visible_long_flag_aliases.snap
@@ -2,4 +2,5 @@
 source: tests/command.rs
 expression: output
 ---
+claptrap_subcommand='test'
 claptrap_test_input='file.txt'

--- a/tests/snapshots/command__visible_short_flag_alias.snap
+++ b/tests/snapshots/command__visible_short_flag_alias.snap
@@ -2,4 +2,5 @@
 source: tests/command.rs
 expression: output
 ---
+claptrap_subcommand='test'
 claptrap_test_input='file.txt'

--- a/tests/snapshots/command__visible_short_flag_aliases.snap
+++ b/tests/snapshots/command__visible_short_flag_aliases.snap
@@ -2,4 +2,5 @@
 source: tests/command.rs
 expression: output
 ---
+claptrap_subcommand='test'
 claptrap_test_input='file.txt'

--- a/tests/snapshots/examples__examples_git_toml.snap
+++ b/tests/snapshots/examples__examples_git_toml.snap
@@ -3,3 +3,4 @@ source: tests/examples.rs
 expression: "String::from_utf8_lossy(&output.stdout)"
 ---
 claptrap_clone_REMOTE: origin
+claptrap_subcommand: clone

--- a/tests/snapshots/examples__examples_pacman_toml.snap
+++ b/tests/snapshots/examples__examples_pacman_toml.snap
@@ -2,6 +2,7 @@
 source: tests/examples.rs
 expression: "String::from_utf8_lossy(&output.stdout)"
 ---
+claptrap_subcommand: sync
 claptrap_sync_info: true
 claptrap_sync_package[0]: claptrap
 claptrap_sync_package[1]: trippy

--- a/tests/snapshots/examples__examples_pacman_yaml.snap
+++ b/tests/snapshots/examples__examples_pacman_yaml.snap
@@ -2,6 +2,7 @@
 source: tests/examples.rs
 expression: "String::from_utf8_lossy(&output.stdout)"
 ---
+claptrap_subcommand: sync
 claptrap_sync_info: true
 claptrap_sync_package[0]: claptrap
 claptrap_sync_package[1]: trippy


### PR DESCRIPTION
## Summary
- output selected subcommand path as `claptrap_subcommand`
- document new variable in git and pacman examples
- update snapshots

## Testing
- `cargo clippy --workspace --all-features --tests -- -Dwarnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6856d3f00c1083298e6048e7d2815a05