### PR TITLE
Add test for Command::subcommand_negates_reqs

### DIFF
--- a/tests/resources/command/subcommand_negates_reqs.args
+++ b/tests/resources/command/subcommand_negates_reqs.args
@@ -1,0 +1,1 @@
+test --arg value

--- a/tests/resources/command/subcommand_negates_reqs.toml
+++ b/tests/resources/command/subcommand_negates_reqs.toml
@@ -1,0 +1,8 @@
+name = "myprog"
+subcommand-negates-reqs = true
+[args]
+opt = { long = "opt", required = true, action = "set" }
+[[subcommands]]
+name = "test"
+[subcommands.args]
+arg = { long = "arg", action = "set" }

--- a/tests/snapshots/tests__command__subcommand_negates_reqs.snap
+++ b/tests/snapshots/tests__command__subcommand_negates_reqs.snap
@@ -1,0 +1,5 @@
+---
+source: tests/tests.rs
+expression: "super::run(spec, args)"
+---
+claptrap_test_arg='value'

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -115,6 +115,7 @@ mod command {
     #[test_case(case!("command", "external_subcommand_value_parser"))]
     #[test_case(case!("command", "args_conflicts_with_subcommands"))]
     #[test_case(case!("command", "subcommand_precedence_over_arg"))]
+    #[test_case(case!("command", "subcommand_negates_reqs"))]
     #[test_case(case!("command", "subcommand_value_name"))]
     #[test_case(case!("command", "subcommand_help_heading"))]
     fn test_command((name, spec, args): (&str, &str, &str)) {


### PR DESCRIPTION
## Summary
- support `Command::subcommand_negates_reqs`
- add test resources and snapshot

## Testing
- `cargo fmt --all`
- `cargo clippy --workspace --all-features --tests -- -Dwarnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6859650295a08329b0650a7c698243aa