### PR TITLE
Add clap feature summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,38 @@
 
 Bring the power of [`clap`](https://crates.io/crates/clap) command line parsing to shell scripts.
 
+## Features
+
+- **Spec driven**: define your CLI once in `toml`, `yaml` or `json` and reuse it across shells.
+- **Safe evaluation**: outputs `cat` commands for usage and errors so scripts can `eval` them safely.
+- **Subcommand aware**: nested subcommands produce scoped environment variables.
+- **Shell quoting**: values are quoted and arrays are emitted for multi value options.
+- **Generate extras**: build completions, man pages, documentation and template scripts.
+- **Flexible sources**: load specs from files or `stdin`; path and format can come from environment variables.
+
+## Clap features
+
+- **Subcommands**: nested subcommands, optional subcommand requirements and precedence rules.
+- **Argument groups**: express mutual exclusion or dependencies between related options.
+- **Aliases**: hidden and visible aliases for commands and arguments.
+- **Short and long flags**: standard single-character or word-style options.
+- **Environment variables**: define arguments that read from the environment when not provided.
+- **Default values**: set static or conditional defaults for arguments.
+- **Custom help**: add before/after text and tailor help templates.
+- **Conflicts and requirements**: ensure options are used in compatible combinations.
+- **Typed parsing**: parse values as numbers, booleans or other typed data.
+- **Color and styles**: use clap's color choices and style sheets for help output.
+- **Infer subcommands**: allow abbreviated subcommand names.
+- **Infer long flags**: accept partially typed long option names.
+- **External subcommands**: forward unknown commands to other programs.
+- **Optional positionals**: let required positionals be omitted when desired.
+- **Version propagation**: share version info across subcommands or disable it entirely.
+- **Display order**: control the ordering of arguments and headings in help.
+- **Argument actions**: automatically set, append, count or toggle values.
+- **Value hints**: suggest file paths, commands or URLs for completions.
+- **Conditional defaults**: compute defaults from the presence or value of other args.
+- **Multi-value parsing**: accept repeated values via delimiters or terminators.
+
 ## Examples
 
 `myapp.sh`:


### PR DESCRIPTION
## Summary
- document features provided by `claptrap`
- outline key clap features supported

## Testing
- `cargo fmt --all`
- `cargo clippy --workspace --all-features --tests -- -Dwarnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68596270f87c8329a3ad20f76dc054d2